### PR TITLE
Add a numFavoritesScorer and numRepliesScorer

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,13 +1,13 @@
 import { mastodon } from "masto";
 import { FeedFetcher, StatusType, weightsType } from "./types";
-import { favsFeatureScorer, interactsFeatureScorer, reblogsFeatureScorer, diversityFeedScorer, reblogsFeedScorer, FeatureScorer, FeedScorer, topPostFeatureScorer } from "./scorer";
+import { favsFeatureScorer, interactsFeatureScorer, numFavoritesScorer, reblogsFeatureScorer, diversityFeedScorer, reblogsFeedScorer, FeatureScorer, FeedScorer, topPostFeatureScorer } from "./scorer";
 import getHomeFeed from "./feeds/homeFeed";
 import Paginator from "./Paginator";
 import chaosFeatureScorer from "./scorer/feature/chaosFeatureScorer";
 export default class TheAlgorithm {
     user: mastodon.v1.Account;
     fetchers: (typeof getHomeFeed)[];
-    featureScorer: (favsFeatureScorer | interactsFeatureScorer | reblogsFeatureScorer | topPostFeatureScorer | chaosFeatureScorer)[];
+    featureScorer: (favsFeatureScorer | interactsFeatureScorer | reblogsFeatureScorer | topPostFeatureScorer | numFavoritesScorer | chaosFeatureScorer)[];
     feedScorer: (diversityFeedScorer | reblogsFeedScorer)[];
     feed: StatusType[];
     api: mastodon.rest.Client;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,13 +1,13 @@
 import { mastodon } from "masto";
 import { FeedFetcher, StatusType, weightsType } from "./types";
-import { favsFeatureScorer, interactsFeatureScorer, numFavoritesScorer, reblogsFeatureScorer, diversityFeedScorer, reblogsFeedScorer, FeatureScorer, FeedScorer, topPostFeatureScorer } from "./scorer";
+import { favsFeatureScorer, interactsFeatureScorer, numFavoritesScorer, numRepliesScorer, reblogsFeatureScorer, diversityFeedScorer, reblogsFeedScorer, FeatureScorer, FeedScorer, topPostFeatureScorer } from "./scorer";
 import getHomeFeed from "./feeds/homeFeed";
 import Paginator from "./Paginator";
 import chaosFeatureScorer from "./scorer/feature/chaosFeatureScorer";
 export default class TheAlgorithm {
     user: mastodon.v1.Account;
     fetchers: (typeof getHomeFeed)[];
-    featureScorer: (favsFeatureScorer | interactsFeatureScorer | reblogsFeatureScorer | topPostFeatureScorer | numFavoritesScorer | chaosFeatureScorer)[];
+    featureScorer: (favsFeatureScorer | interactsFeatureScorer | reblogsFeatureScorer | topPostFeatureScorer | numFavoritesScorer | numRepliesScorer | chaosFeatureScorer)[];
     feedScorer: (diversityFeedScorer | reblogsFeedScorer)[];
     feed: StatusType[];
     api: mastodon.rest.Client;

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,6 +20,7 @@ class TheAlgorithm {
         new scorer_1.interactsFeatureScorer(),
         new scorer_1.topPostFeatureScorer(),
         new chaosFeatureScorer_1.default(),
+        new scorer_1.numFavoritesScorer(),
     ];
     feedScorer = [new scorer_1.reblogsFeedScorer(), new scorer_1.diversityFeedScorer()];
     feed = [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,6 +21,7 @@ class TheAlgorithm {
         new scorer_1.topPostFeatureScorer(),
         new chaosFeatureScorer_1.default(),
         new scorer_1.numFavoritesScorer(),
+        new scorer_1.numRepliesScorer(),
     ];
     feedScorer = [new scorer_1.reblogsFeedScorer(), new scorer_1.diversityFeedScorer()];
     feed = [];

--- a/dist/scorer/feature/favsFeatureScorer.d.ts
+++ b/dist/scorer/feature/favsFeatureScorer.d.ts
@@ -1,6 +1,6 @@
 import FeatureScorer from '../FeatureScorer';
-import { StatusType } from '../../types';
 import { mastodon } from 'masto';
+import { StatusType } from '../../types';
 export default class favsFeatureScorer extends FeatureScorer {
     constructor();
     score(_api: mastodon.rest.Client, status: StatusType): Promise<number>;

--- a/dist/scorer/feature/favsFeatureScorer.js
+++ b/dist/scorer/feature/favsFeatureScorer.js
@@ -3,6 +3,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+/*
+ * Score how many times the current user has favorited the tooter in the past.
+ */
 const FeatureScorer_1 = __importDefault(require("../FeatureScorer"));
 const FeatureStore_1 = __importDefault(require("../../features/FeatureStore"));
 class favsFeatureScorer extends FeatureScorer_1.default {

--- a/dist/scorer/index.d.ts
+++ b/dist/scorer/index.d.ts
@@ -4,6 +4,7 @@ import reblogsFeatureScorer from "./feature/reblogsFeatureScorer";
 import topPostFeatureScorer from "./feature/topPostFeatureScorer";
 import diversityFeedScorer from "./feed/diversityFeedScorer";
 import reblogsFeedScorer from "./feed/reblogsFeedScorer";
+import numFavoritesScorer from "./feature/numFavoritesScorer";
 import FeedScorer from "./FeedScorer";
 import FeatureScorer from "./FeatureScorer";
-export { favsFeatureScorer, interactsFeatureScorer, reblogsFeatureScorer, topPostFeatureScorer, diversityFeedScorer, reblogsFeedScorer, FeedScorer, FeatureScorer };
+export { favsFeatureScorer, interactsFeatureScorer, reblogsFeatureScorer, topPostFeatureScorer, diversityFeedScorer, numFavoritesScorer, reblogsFeedScorer, FeedScorer, FeatureScorer };

--- a/dist/scorer/index.d.ts
+++ b/dist/scorer/index.d.ts
@@ -5,6 +5,7 @@ import topPostFeatureScorer from "./feature/topPostFeatureScorer";
 import diversityFeedScorer from "./feed/diversityFeedScorer";
 import reblogsFeedScorer from "./feed/reblogsFeedScorer";
 import numFavoritesScorer from "./feature/numFavoritesScorer";
+import numRepliesScorer from "./feature/numRepliesScorer";
 import FeedScorer from "./FeedScorer";
 import FeatureScorer from "./FeatureScorer";
-export { favsFeatureScorer, interactsFeatureScorer, reblogsFeatureScorer, topPostFeatureScorer, diversityFeedScorer, numFavoritesScorer, reblogsFeedScorer, FeedScorer, FeatureScorer };
+export { favsFeatureScorer, interactsFeatureScorer, reblogsFeatureScorer, topPostFeatureScorer, diversityFeedScorer, numFavoritesScorer, numRepliesScorer, reblogsFeedScorer, FeedScorer, FeatureScorer };

--- a/dist/scorer/index.js
+++ b/dist/scorer/index.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.FeatureScorer = exports.FeedScorer = exports.reblogsFeedScorer = exports.numFavoritesScorer = exports.diversityFeedScorer = exports.topPostFeatureScorer = exports.reblogsFeatureScorer = exports.interactsFeatureScorer = exports.favsFeatureScorer = void 0;
+exports.FeatureScorer = exports.FeedScorer = exports.reblogsFeedScorer = exports.numRepliesScorer = exports.numFavoritesScorer = exports.diversityFeedScorer = exports.topPostFeatureScorer = exports.reblogsFeatureScorer = exports.interactsFeatureScorer = exports.favsFeatureScorer = void 0;
 const favsFeatureScorer_1 = __importDefault(require("./feature/favsFeatureScorer"));
 exports.favsFeatureScorer = favsFeatureScorer_1.default;
 const interactsFeatureScorer_1 = __importDefault(require("./feature/interactsFeatureScorer"));
@@ -18,6 +18,8 @@ const reblogsFeedScorer_1 = __importDefault(require("./feed/reblogsFeedScorer"))
 exports.reblogsFeedScorer = reblogsFeedScorer_1.default;
 const numFavoritesScorer_1 = __importDefault(require("./feature/numFavoritesScorer"));
 exports.numFavoritesScorer = numFavoritesScorer_1.default;
+const numRepliesScorer_1 = __importDefault(require("./feature/numRepliesScorer"));
+exports.numRepliesScorer = numRepliesScorer_1.default;
 const FeedScorer_1 = __importDefault(require("./FeedScorer"));
 exports.FeedScorer = FeedScorer_1.default;
 const FeatureScorer_1 = __importDefault(require("./FeatureScorer"));

--- a/dist/scorer/index.js
+++ b/dist/scorer/index.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.FeatureScorer = exports.FeedScorer = exports.reblogsFeedScorer = exports.diversityFeedScorer = exports.topPostFeatureScorer = exports.reblogsFeatureScorer = exports.interactsFeatureScorer = exports.favsFeatureScorer = void 0;
+exports.FeatureScorer = exports.FeedScorer = exports.reblogsFeedScorer = exports.numFavoritesScorer = exports.diversityFeedScorer = exports.topPostFeatureScorer = exports.reblogsFeatureScorer = exports.interactsFeatureScorer = exports.favsFeatureScorer = void 0;
 const favsFeatureScorer_1 = __importDefault(require("./feature/favsFeatureScorer"));
 exports.favsFeatureScorer = favsFeatureScorer_1.default;
 const interactsFeatureScorer_1 = __importDefault(require("./feature/interactsFeatureScorer"));
@@ -16,6 +16,8 @@ const diversityFeedScorer_1 = __importDefault(require("./feed/diversityFeedScore
 exports.diversityFeedScorer = diversityFeedScorer_1.default;
 const reblogsFeedScorer_1 = __importDefault(require("./feed/reblogsFeedScorer"));
 exports.reblogsFeedScorer = reblogsFeedScorer_1.default;
+const numFavoritesScorer_1 = __importDefault(require("./feature/numFavoritesScorer"));
+exports.numFavoritesScorer = numFavoritesScorer_1.default;
 const FeedScorer_1 = __importDefault(require("./FeedScorer"));
 exports.FeedScorer = FeedScorer_1.default;
 const FeatureScorer_1 = __importDefault(require("./FeatureScorer"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { FeedFetcher, StatusType, weightsType } from "./types";
 import {
     favsFeatureScorer,
     interactsFeatureScorer,
+    numFavoritesScorer,
     reblogsFeatureScorer,
     diversityFeedScorer,
     reblogsFeedScorer,
@@ -27,6 +28,7 @@ export default class TheAlgorithm {
         new interactsFeatureScorer(),
         new topPostFeatureScorer(),
         new chaosFeatureScorer(),
+        new numFavoritesScorer(),
     ];
     feedScorer = [new reblogsFeedScorer(), new diversityFeedScorer()]
     feed: StatusType[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
     favsFeatureScorer,
     interactsFeatureScorer,
     numFavoritesScorer,
+    numRepliesScorer,
     reblogsFeatureScorer,
     diversityFeedScorer,
     reblogsFeedScorer,
@@ -29,6 +30,7 @@ export default class TheAlgorithm {
         new topPostFeatureScorer(),
         new chaosFeatureScorer(),
         new numFavoritesScorer(),
+        new numRepliesScorer(),
     ];
     feedScorer = [new reblogsFeedScorer(), new diversityFeedScorer()]
     feed: StatusType[] = [];

--- a/src/scorer/feature/numFavoritesScorer.ts
+++ b/src/scorer/feature/numFavoritesScorer.ts
@@ -1,23 +1,23 @@
 /*
- * Score how many times the current user has favorited the tooter in the past.
+ * Score how many times the toot has been favorited by other users.
  */
 import FeatureScorer from '../FeatureScorer';
 import FeatureStorage from '../../features/FeatureStore';
 import { mastodon } from 'masto';
 import { StatusType } from '../../types';
 
-export default class favsFeatureScorer extends FeatureScorer {
 
+export default class numFavoritesScorer extends FeatureScorer {
     constructor() {
         super({
             featureGetter: (api: mastodon.rest.Client) => FeatureStorage.getTopFavs(api),
-            verboseName: "Favs",
-            description: "Posts that are from your most favorited users",
+            verboseName: "numFavorites",
+            description: "Favor posts that have been favorited by a lot of other users",
             defaultWeight: 1,
         })
     }
 
     async score(_api: mastodon.rest.Client, status: StatusType) {
-        return (status.account.acct in this.feature) ? this.feature[status.account.acct] : 0
+        return status?.favouritesCount || 0;
     }
-}
+};

--- a/src/scorer/feature/numRepliesScorer.ts
+++ b/src/scorer/feature/numRepliesScorer.ts
@@ -1,0 +1,23 @@
+/*
+ * Score how many times the toot has been replied to by other users.
+ */
+import FeatureScorer from '../FeatureScorer';
+import FeatureStorage from '../../features/FeatureStore';
+import { mastodon } from 'masto';
+import { StatusType } from '../../types';
+
+
+export default class numRepliesScorer extends FeatureScorer {
+    constructor() {
+        super({
+            featureGetter: (api: mastodon.rest.Client) => FeatureStorage.getTopFavs(api),
+            verboseName: "numReplies",
+            description: "Favor posts that have been replied to many times",
+            defaultWeight: 1,
+        })
+    }
+
+    async score(_api: mastodon.rest.Client, status: StatusType) {
+        return status?.repliesCount || 0;
+    }
+};

--- a/src/scorer/index.ts
+++ b/src/scorer/index.ts
@@ -5,6 +5,7 @@ import topPostFeatureScorer from "./feature/topPostFeatureScorer";
 import diversityFeedScorer from "./feed/diversityFeedScorer";
 import reblogsFeedScorer from "./feed/reblogsFeedScorer";
 import numFavoritesScorer from "./feature/numFavoritesScorer";
+import numRepliesScorer from "./feature/numRepliesScorer";
 import FeedScorer from "./FeedScorer";
 import FeatureScorer from "./FeatureScorer";
 
@@ -16,6 +17,7 @@ export {
     topPostFeatureScorer,
     diversityFeedScorer,
     numFavoritesScorer,
+    numRepliesScorer,
     reblogsFeedScorer,
     FeedScorer,
     FeatureScorer

--- a/src/scorer/index.ts
+++ b/src/scorer/index.ts
@@ -4,6 +4,7 @@ import reblogsFeatureScorer from "./feature/reblogsFeatureScorer";
 import topPostFeatureScorer from "./feature/topPostFeatureScorer";
 import diversityFeedScorer from "./feed/diversityFeedScorer";
 import reblogsFeedScorer from "./feed/reblogsFeedScorer";
+import numFavoritesScorer from "./feature/numFavoritesScorer";
 import FeedScorer from "./FeedScorer";
 import FeatureScorer from "./FeatureScorer";
 
@@ -14,6 +15,7 @@ export {
     reblogsFeatureScorer,
     topPostFeatureScorer,
     diversityFeedScorer,
+    numFavoritesScorer,
     reblogsFeedScorer,
     FeedScorer,
     FeatureScorer


### PR DESCRIPTION
* `numFavoritesScorer` uses the raw number of favorites on a toot
* `numRepliesScorer` uses the raw number of times a toot has been replied to by anyone

Seems like all the files in `dist/` shouldn't be in the repo? but i put the changes in this PR anyways.